### PR TITLE
fixed line ending format

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,6 +1,4 @@
 # Fetch ubuntu 22.04 LTS docker image
-# since the current version of HappyBase (1.2.0) is compatible only with Python 3.7 or earlier, check for updates
-# https://happybase.readthedocs.io/en/latest/news.html
 FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
windows throw $'\r' line not found for hbase-env.sh file due to a change in line format between Windows and Unix systems.